### PR TITLE
feat: Added support for custom tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
+  extra_tags = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
-  extra_tags = var.extra_tags
+  extra_tags  = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -106,9 +106,9 @@ variable "enforcement" {
   description = "Specifies if the encrypted Virtual Network allows VM that does not support encryption. Possible values are DropUnencrypted and AllowUnencrypted."
 }
 variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
+  type        = map(sting)
+  default     = null
+  description = "Variable to pass extra tags."
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "managedby" {
   description = "ManagedBy, eg 'CloudDrove'."
 }
 
+variable "extra_tags" {
+  type        = map(string)
+  default     = null
+  description = "Variable to pass extra tags."
+}
+
 variable "enable" {
   type        = bool
   default     = true
@@ -104,11 +110,6 @@ variable "enforcement" {
   type        = string
   default     = null
   description = "Specifies if the encrypted Virtual Network allows VM that does not support encryption. Possible values are DropUnencrypted and AllowUnencrypted."
-}
-variable "extra_tags" {
-  type        = map(sting)
-  default     = null
-  description = "Variable to pass extra tags."
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -105,5 +105,11 @@ variable "enforcement" {
   default     = null
   description = "Specifies if the encrypted Virtual Network allows VM that does not support encryption. Possible values are DropUnencrypted and AllowUnencrypted."
 }
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}
+
 
 


### PR DESCRIPTION
## what
* Add custom tags

## why
* Azure Modules only support tags from module.labels.tags, we want that any user to pass their custom tags.
